### PR TITLE
JNG-4198 Remove ternary padding

### DIFF
--- a/judo-runtime-core-jsl-itest/pom.xml
+++ b/judo-runtime-core-jsl-itest/pom.xml
@@ -64,6 +64,7 @@
                                 <source>${project.basedir}/target/generated-sources/model/sdk/OrderManagement</source>
                                 <source>${project.basedir}/target/generated-sources/model/sdk/QueryModel</source>
                                 <source>${project.basedir}/target/generated-sources/model/sdk/Abstract</source>
+                                <source>${project.basedir}/target/generated-sources/model/sdk/TernaryTest</source>
                             </sources>
                         </configuration> 
                    </execution>

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/TernaryTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/TernaryTest.java
@@ -57,6 +57,7 @@ public class TernaryTest extends AbstractJslTest {
         assertEquals("!!false!!", a.getTs6().orElseThrow());
         assertEquals("  aaa", a.getTs7().orElseThrow());
 
+        // TODO: JNG-3839
 //        Optional<BBB> t2 = aDao.getT2(a);
 //        assertTrue(t2.isEmpty());
 //        List<BBB> t3 = aDao.getT3(a);

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/TernaryTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/TernaryTest.java
@@ -1,0 +1,66 @@
+package hu.blackbelt.judo.runtime.core.jsl;
+
+/*-
+ * #%L
+ * JUDO Runtime Core :: JUDO Language Specification DSL Integration Tests
+ * %%
+ * Copyright (C) 2018 - 2022 BlackBelt Technology
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import com.google.inject.Inject;
+import com.google.inject.Module;
+import hu.blackbelt.judo.runtime.core.jsl.itest.ternarytest.guice.ternarytest.TernaryTestDaoModules;
+import hu.blackbelt.judo.runtime.core.jsl.itest.ternarytest.sdk.ternarytest.ternarytest.AAA;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+public class TernaryTest extends AbstractJslTest {
+
+    @Inject AAA.AAADao aDao;
+
+    @Override
+    public Module getModelDaoModule() {
+        return new TernaryTestDaoModules();
+    }
+
+    @Override
+    public String getModelName() {
+        return "TernaryTest";
+    }
+
+    @Test
+    public void testTernaries() {
+        AAA a = aDao.create(AAA.builder().build());
+
+        assertEquals("true", a.getTs().orElseThrow());
+        assertEquals("aaa", a.getTs1().orElseThrow());
+        assertEquals("true  ", a.getTs2().orElseThrow());
+        assertEquals("aaa", a.getTs3().orElseThrow());
+        assertEquals("false", a.getTs4().orElseThrow());
+        assertEquals("false", a.getTs5().orElseThrow());
+        assertEquals("!!false!!", a.getTs6().orElseThrow());
+        assertEquals("  aaa", a.getTs7().orElseThrow());
+
+//        Optional<BBB> t2 = aDao.getT2(a);
+//        assertTrue(t2.isEmpty());
+//        List<BBB> t3 = aDao.getT3(a);
+//        assertTrue(t3.isEmpty());
+    }
+
+}

--- a/judo-runtime-core-jsl-itest/src/test/resources/model/TernaryTest.jsl
+++ b/judo-runtime-core-jsl-itest/src/test/resources/model/TernaryTest.jsl
@@ -15,8 +15,8 @@ entity AAA {
     derived String ts5 => false ? self.name : "false";
     derived String ts6 => false ? "true  " : "!!false!!";
     derived String ts7 => false ? self.name : self.name1;
-    // derived BBB tb => TernaryTest::CCC!size() == 1 ? TernaryTest::CCC!any() : TernaryTest::DDD!any();
-    // derived BBB[] tb1 => TernaryTest::BBB!size() == 1 ? TernaryTest::CCC : TernaryTest::DDD;
+    // derived BBB tb => TernaryTest::CCC!size() == 1 ? TernaryTest::CCC!any() : TernaryTest::DDD!any(); // TODO: JNG-3839
+    // derived BBB[] tb1 => TernaryTest::BBB!size() == 1 ? TernaryTest::CCC : TernaryTest::DDD; // TODO: JNG-3839
 }
 
 entity BBB {

--- a/judo-runtime-core-jsl-itest/src/test/resources/model/TernaryTest.jsl
+++ b/judo-runtime-core-jsl-itest/src/test/resources/model/TernaryTest.jsl
@@ -1,0 +1,27 @@
+model TernaryTest;
+
+type string String(min-size = 0, max-size = 255);
+type boolean Boolean;
+
+entity AAA {
+    field String name = "aaa";
+    field String name1 = "  aaa";
+
+    derived String ts => true ? "true" : "false";
+    derived String ts1 => true ? self.name : "false";
+    derived String ts2 => true ? "true  " : "!!false!!";
+    derived String ts3 => true ? self.name : self.name;
+    derived String ts4 => false ? "true" : "false";
+    derived String ts5 => false ? self.name : "false";
+    derived String ts6 => false ? "true  " : "!!false!!";
+    derived String ts7 => false ? self.name : self.name1;
+    // derived BBB tb => TernaryTest::CCC!size() == 1 ? TernaryTest::CCC!any() : TernaryTest::DDD!any();
+    // derived BBB[] tb1 => TernaryTest::BBB!size() == 1 ? TernaryTest::CCC : TernaryTest::DDD;
+}
+
+entity BBB {
+    field String name;
+}
+
+entity CCC extends BBB {}
+entity DDD extends BBB {}

--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,10 @@
         </osgi-transaction-import>
 
 
-        <epsilon-runtime-version>1.5.0</epsilon-runtime-version>
-        <judo-tatami-core-version>1.1.2</judo-tatami-core-version>
-        <judo-tatami-jsl-version>1.1.2</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.3</judo-runtime-core-version>
+        <epsilon-runtime-version>1.5.1.20221026_231334_709fc633_develop</epsilon-runtime-version>
+        <judo-tatami-core-version>1.1.3.20221027_020917_d7259d09_develop</judo-tatami-core-version>
+        <judo-tatami-jsl-version>1.1.3.20221027_035126_0865e1a1_develop</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.4.20221028_155525_5d3ed06e_bugfix_JNG_4198_Remove_ternary_padding</judo-runtime-core-version>
 
         <!-- Code Quality-->
         <sonar-maven-plugin-version>3.9.1.2184</sonar-maven-plugin-version>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4198" title="JNG-4198" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4198</a>  Ternary operation produces whitespace padded string if used with string constants
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

JNG-4198 Remove ternary padding