### PR TITLE
JNG-4180 fix decimal avg

### DIFF
--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/FunctionsTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/FunctionsTest.java
@@ -687,12 +687,12 @@ public class FunctionsTest extends AbstractJslTest {
         assertEquals(Optional.of(133L), collectionFunctions.getSumChildrenRelation());
 
         assertEquals(Optional.of(34L), collectionFunctions.getAvgChildrenField());
-        assertEquals(Optional.of(26L), collectionFunctions.getAvgChildrenRelation());
+        assertEquals(Optional.of(27L), collectionFunctions.getAvgChildrenRelation());
 
         assertEquals(Optional.of(34.2), collectionFunctions.getAvgScaledChildrenField());
         assertEquals(Optional.of(26.6), collectionFunctions.getAvgScaledChildrenRelation());
 
-        assertEquals(Optional.of(34L), collectionFunctions.getDivisionConst());
+        assertEquals(Optional.of(35L), collectionFunctions.getDivisionConst());
         assertEquals(Optional.of(35L), collectionFunctions.getRoundConst());
 
         assertEquals(2, collectionFunctionsDao.queryFirstChildrenField(collectionFunctions).execute().size());

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/FunctionsTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/FunctionsTest.java
@@ -689,10 +689,8 @@ public class FunctionsTest extends AbstractJslTest {
         assertEquals(Optional.of(34L), collectionFunctions.getAvgChildrenField());
         assertEquals(Optional.of(26L), collectionFunctions.getAvgChildrenRelation());
 
-        /* FIXME JNG-4180
-        assertEquals(Optional.of(34.5), collectionFunctions.getAvgScaledChildrenField());
-        assertEquals(Optional.of(33.5), collectionFunctions.getAvgScaledChildrenRelation());
-        */
+        assertEquals(Optional.of(34.2), collectionFunctions.getAvgScaledChildrenField());
+        assertEquals(Optional.of(26.6), collectionFunctions.getAvgScaledChildrenRelation());
 
         assertEquals(Optional.of(34L), collectionFunctions.getDivisionConst());
         assertEquals(Optional.of(35L), collectionFunctions.getRoundConst());

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/OperatorsTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/OperatorsTest.java
@@ -175,7 +175,7 @@ public class OperatorsTest extends AbstractJslTest {
         assertFalse(operators.getAdditionUndefinedFalse().orElseThrow());
         assertEquals(Optional.of(33), operators.getSubtraction());
         assertEquals(Optional.of(70), operators.getMultiplication());
-        assertEquals(Optional.of(17), operators.getDivision());
+        assertEquals(Optional.of(18), operators.getDivision());
         assertEquals(Optional.of(17), operators.getDivisionWhole());
         assertEquals(Optional.of(1), operators.getModulo());
         assertEquals(Optional.of(false), operators.getLt());

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/PrecisionTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/PrecisionTest.java
@@ -118,7 +118,6 @@ public class PrecisionTest extends AbstractJslTest {
     }
 
     @Test
-    @Disabled("https://blackbelt.atlassian.net/browse/JNG-4462") // TODO
     @Requirement(reqs = {
             "REQ-TYPE-001",
             "REQ-TYPE-005",

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/PrecisionTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/PrecisionTest.java
@@ -28,7 +28,6 @@ import hu.blackbelt.judo.psm.generator.sdk.core.test.guice.PrimitivesDaoModules;
 import hu.blackbelt.judo.requirement.report.annotation.Requirement;
 import hu.blackbelt.judo.runtime.core.exception.ValidationException;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/PrecisionTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/PrecisionTest.java
@@ -28,6 +28,7 @@ import hu.blackbelt.judo.psm.generator.sdk.core.test.guice.PrimitivesDaoModules;
 import hu.blackbelt.judo.requirement.report.annotation.Requirement;
 import hu.blackbelt.judo.runtime.core.exception.ValidationException;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -117,6 +118,7 @@ public class PrecisionTest extends AbstractJslTest {
     }
 
     @Test
+    @Disabled("https://blackbelt.atlassian.net/browse/JNG-4462") // TODO
     @Requirement(reqs = {
             "REQ-TYPE-001",
             "REQ-TYPE-005",

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
             javax.transaction.xa;version=!,
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
-        <judo-tatami-jsl-version>1.1.4.20230216_194918_295d2b4c_feature_JNG_4180_fix_decimal_avg</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230216_193949_abd68725_feature_JNG_4180_fix_decimal_avg</judo-runtime-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230217_091101_c3a46cb3_feature_JNG_4180_fix_decimal_avg</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230217_085601_48140f09_feature_JNG_4180_fix_decimal_avg</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230207_042651_68b72227_develop</judo-psm-generator-sdk-core-version>
         <judo-meta-psm-version>1.2.4.20230207_042332_0fff9a62_develop</judo-meta-psm-version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
             javax.transaction.xa;version=!,
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
-        <judo-tatami-jsl-version>1.1.4.20230217_091101_c3a46cb3_feature_JNG_4180_fix_decimal_avg</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230217_085601_48140f09_feature_JNG_4180_fix_decimal_avg</judo-runtime-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230217_115310_68c105ee_feature_JNG_4180_fix_decimal_avg</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230217_113800_3aabaa3b_feature_JNG_4180_fix_decimal_avg</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230207_042651_68b72227_develop</judo-psm-generator-sdk-core-version>
         <judo-meta-psm-version>1.2.4.20230207_042332_0fff9a62_develop</judo-meta-psm-version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
             javax.transaction.xa;version=!,
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
-        <judo-tatami-jsl-version>1.1.4.20230215_155743_e3b184dc_feature_JNG_4180_fix_decimal_avg</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230215_154740_087da5ed_feature_JNG_4180_fix_decimal_avg</judo-runtime-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230216_102647_9cf63946_feature_JNG_4180_fix_decimal_avg</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230216_101639_ee6d5e16_feature_JNG_4180_fix_decimal_avg</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230207_042651_68b72227_develop</judo-psm-generator-sdk-core-version>
         <judo-meta-psm-version>1.2.4.20230207_042332_0fff9a62_develop</judo-meta-psm-version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
             javax.transaction.xa;version=!,
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
-        <judo-tatami-jsl-version>1.1.4.20230216_102647_9cf63946_feature_JNG_4180_fix_decimal_avg</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230216_101639_ee6d5e16_feature_JNG_4180_fix_decimal_avg</judo-runtime-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230216_194918_295d2b4c_feature_JNG_4180_fix_decimal_avg</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230216_193949_abd68725_feature_JNG_4180_fix_decimal_avg</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230207_042651_68b72227_develop</judo-psm-generator-sdk-core-version>
         <judo-meta-psm-version>1.2.4.20230207_042332_0fff9a62_develop</judo-meta-psm-version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
             javax.transaction.xa;version=!,
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
-        <judo-tatami-jsl-version>1.1.4.20230215_040802_10715d83_develop</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230214_094224_abc2c73b_develop</judo-runtime-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230215_155743_e3b184dc_feature_JNG_4180_fix_decimal_avg</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230215_154740_087da5ed_feature_JNG_4180_fix_decimal_avg</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230207_042651_68b72227_develop</judo-psm-generator-sdk-core-version>
         <judo-meta-psm-version>1.2.4.20230207_042332_0fff9a62_develop</judo-meta-psm-version>
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4180" title="JNG-4180" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4180</a>  !avg() function produces truncated result even if fed into Scaled data type
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

