### PR TITLE
JNG-4864 Remove cast before time component extraction in hsqldb

### DIFF
--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/TestStaticQueryDao.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/TestStaticQueryDao.java
@@ -250,15 +250,14 @@ public class TestStaticQueryDao extends AbstractJslTest {
 
         // Timestamp
         assertEquals(LocalDateTime.parse("2022-07-11T19:09:33"), timestampWithoutParamQueryDao.execute());
-        // TODO JNG-4864
-//        assertEquals(
-//                LocalDateTime.parse("2023-03-03T12:24:45"),
-//                timestampWithParamQueryDao.execute(TimestampWithParamQueryParameter
-//                        .builder()
-//                        .withTimestampDate(LocalDate.of(2023, 3, 3))
-//                        .withTimestampTime(LocalTime.of(12, 24, 45))
-//                        .build())
-//        );
+        assertEquals(
+                LocalDateTime.parse("2023-03-03T12:24:45"),
+                timestampWithParamQueryDao.execute(TimestampWithParamQueryParameter
+                        .builder()
+                        .withTimestampDate(LocalDate.of(2023, 3, 3))
+                        .withTimestampTime(LocalTime.of(12, 24, 45))
+                        .build())
+        );
         assertEquals(
                 LocalDateTime.parse("2021-02-28T10:30:01"),
                 timestampWithDefaultParamQueryDao.execute(TimestampWithDefaultParamQueryParameter.builder().build())

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
             javax.transaction.xa;version=!,
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
-        <judo-tatami-jsl-version>1.1.4.20230525_040719_38f34d6a_develop</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230524_134847_bef03d7a_develop</judo-runtime-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230531_123256_6200a5ec_bugfix_JNG_4864_Remove_cast_before_time_component_extraction_in_hsqldb</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230531_122635_76067dd8_bugfix_JNG_4864_Remove_cast_before_time_component_extraction_in_hsqldb</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230531_113750_b8c9389e_develop</judo-psm-generator-sdk-core-version>
         <judo-meta-psm-version>1.3.0.20230516_100351_2fb48f5a_develop</judo-meta-psm-version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@
             javax.transaction.xa;version=!,
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
-        <judo-tatami-jsl-version>1.1.4.20230525_040719_38f34d6a_develop</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230524_134847_bef03d7a_develop</judo-runtime-core-version>
-        <judo-psm-generator-sdk-core-version>1.0.0.20230531_083248_09e73178_feature_JNG_4857_Single_static_query_should_return_single_value_in_SDK</judo-psm-generator-sdk-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230531_123256_6200a5ec_bugfix_JNG_4864_Remove_cast_before_time_component_extraction_in_hsqldb</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230531_122635_76067dd8_bugfix_JNG_4864_Remove_cast_before_time_component_extraction_in_hsqldb</judo-runtime-core-version>
+        <judo-psm-generator-sdk-core-version>1.0.0.20230531_113750_b8c9389e_develop</judo-psm-generator-sdk-core-version>
         <judo-meta-psm-version>1.3.0.20230516_100351_2fb48f5a_develop</judo-meta-psm-version>
 
         <!-- Code Quality-->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4864" title="JNG-4864" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4864</a>  Error when executing query dao with timestamp return type
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

JNG-4864 Remove cast before time component extraction in hsqldb