### PR TITLE
JNG-4888 Fix attribute mapping with mandatoriness and default settings

### DIFF
--- a/judo-runtime-core-jsl-itest/pom.xml
+++ b/judo-runtime-core-jsl-itest/pom.xml
@@ -395,6 +395,16 @@
                             <sources>${basedir}/src/test/resources/model/AutoMappedTransferSingleEntityModel</sources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>generate-psm-test-model-from-artifact-PrimitiveAttributeMappingCombinationsModel</id>
+                        <goals>
+                            <goal>parser-workflow</goal>
+                        </goals>
+                        <phase>generate-test-sources</phase>
+                        <configuration>
+                            <sources>${basedir}/src/test/resources/model/PrimitiveAttributeMappingCombinationsModel</sources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -868,6 +878,62 @@
                             <destination>${basedir}/target/generated-test-sources/sdk-core/AutoMappedTransferSingleEntity</destination>
                         </configuration>
                     </execution>
+
+                    <execution>
+                        <id>execute-psm-test-model-from-artifact-PrimitiveAttributeMappingCombinations-Optional</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <psm>
+                                ${basedir}/target/generated-test-sources/model/OptionalModel-psm.model
+                            </psm>
+                            <destination>${basedir}/target/generated-test-sources/sdk-core/OptionalModel</destination>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>execute-psm-test-model-from-artifact-PrimitiveAttributeMappingCombinations-OptionalWithDefault</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <psm>
+                                ${basedir}/target/generated-test-sources/model/OptionalWithDefaultModel-psm.model
+                            </psm>
+                            <destination>${basedir}/target/generated-test-sources/sdk-core/OptionalWithDefaultModel</destination>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>execute-psm-test-model-from-artifact-PrimitiveAttributeMappingCombinations-Required</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <psm>
+                                ${basedir}/target/generated-test-sources/model/RequiredModel-psm.model
+                            </psm>
+                            <destination>${basedir}/target/generated-test-sources/sdk-core/RequiredModel</destination>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>execute-psm-test-model-from-artifact-PrimitiveAttributeMappingCombinations-RequiredWithDefault</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <psm>
+                                ${basedir}/target/generated-test-sources/model/RequiredWithDefaultModel-psm.model
+                            </psm>
+                            <destination>${basedir}/target/generated-test-sources/sdk-core/RequiredWithDefaultModel</destination>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -918,6 +984,10 @@
                                 <source>${project.basedir}/target/generated-test-sources/sdk-core/MappedTransferAggregation</source>
                                 <source>${project.basedir}/target/generated-test-sources/sdk-core/TransferConstructor</source>
                                 <source>${project.basedir}/target/generated-test-sources/sdk-core/AutoMappedTransferSingleEntity</source>
+                                <source>${project.basedir}/target/generated-test-sources/sdk-core/OptionalModel</source>
+                                <source>${project.basedir}/target/generated-test-sources/sdk-core/OptionalWithDefaultModel</source>
+                                <source>${project.basedir}/target/generated-test-sources/sdk-core/RequiredModel</source>
+                                <source>${project.basedir}/target/generated-test-sources/sdk-core/RequiredWithDefaultModel</source>
                             </sources>
                         </configuration>
                    </execution>

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/PrimitiveAttributeMappingCombinations/OptionalTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/PrimitiveAttributeMappingCombinations/OptionalTest.java
@@ -21,13 +21,30 @@ package hu.blackbelt.judo.runtime.core.jsl.transfer.PrimitiveAttributeMappingCom
  */
 
 import com.google.inject.Module;
+import com.google.inject.*;
+import hu.blackbelt.judo.dao.api.ValidationResult;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.api.optionalmodel.optionalmodel.optional.*;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.api.optionalmodel.optionalmodel.optionalmappingoptional.*;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.api.optionalmodel.optionalmodel.optionalwithdefaultmappingoptional.*;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.api.optionalmodel.optionalmodel.requiredmappingoptional.*;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.api.optionalmodel.optionalmodel.requiredwithdefaultmappingoptional.*;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.guice.OptionalModelDaoModules;
+import hu.blackbelt.judo.runtime.core.exception.ValidationException;
 import hu.blackbelt.judo.runtime.core.jsl.AbstractJslTest;
+import hu.blackbelt.judo.sdk.query.StringFilter;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
 public class OptionalTest extends AbstractJslTest {
+
+    @Inject OptionalDao optionalDao;
+    @Inject OptionalMappingOptionalDao optionalMappingOptionalDao;
+    @Inject OptionalWithDefaultMappingOptionalDao optionalWithDefaultMappingOptionalDao;
+    @Inject RequiredMappingOptionalDao requiredMappingOptionalDao;
+    @Inject RequiredWithDefaultMappingOptionalDao requiredWithDefaultMappingOptionalDao;
 
     @Override
     public Module getModelDaoModule() {
@@ -39,20 +56,129 @@ public class OptionalTest extends AbstractJslTest {
         return "OptionalModel";
     }
 
+    @AfterEach
+    public void teardown() {
+        for (Optional optional : optionalDao.query().execute()) {
+            optionalDao.delete(optional);
+        }
+    }
+
     @Test
     public void testOptionalMapping() {
+        OptionalMappingOptional optionalMappingOptional = optionalMappingOptionalDao.create(OptionalMappingOptional.create());
+        assertTrue(optionalMappingOptional.getAttr().isEmpty());
+        assertEquals(1, optionalDao.countAll());
+        assertTrue(optionalDao.query().execute().get(0).getAttr().isEmpty());
+
+        optionalMappingOptional = optionalMappingOptionalDao.create(OptionalMappingOptional.builder().withAttr("initial").build());
+        assertEquals("initial", optionalMappingOptional.getAttr().orElseThrow());
+        assertEquals(2, optionalDao.query().count());
+        assertEquals(1, optionalDao.query().filterByAttr(StringFilter.equalTo("initial")).count());
+
+        optionalMappingOptional.setAttr("updated");
+        optionalMappingOptional = optionalMappingOptionalDao.update(optionalMappingOptional);
+        assertEquals("updated", optionalMappingOptional.getAttr().orElseThrow());
+        assertEquals(2, optionalDao.query().count());
+        assertEquals(1, optionalDao.query().filterByAttr(StringFilter.equalTo("updated")).count());
+        assertEquals(0, optionalDao.query().filterByAttr(StringFilter.equalTo("initial")).count());
+
+        optionalMappingOptional.setAttr(null);
+        optionalMappingOptional = optionalMappingOptionalDao.update(optionalMappingOptional);
+        assertTrue(optionalMappingOptional.getAttr().isEmpty());
+        assertEquals(2, optionalDao.query().count());
+        assertEquals(0, optionalDao.query().filterByAttr(StringFilter.equalTo("updated")).count());
     }
 
     @Test
     public void testOptionalWithDefaultMapping() {
+        OptionalWithDefaultMappingOptional optionalWithDefaultMappingOptional =
+                optionalWithDefaultMappingOptionalDao.create(OptionalWithDefaultMappingOptional.create());
+        assertEquals("OptionalWithDefaultMappingOptional", optionalWithDefaultMappingOptional.getAttr().orElseThrow());
+        assertEquals(1, optionalWithDefaultMappingOptionalDao.countAll());
+        assertEquals("OptionalWithDefaultMappingOptional", optionalWithDefaultMappingOptionalDao.query().execute().get(0).getAttr().orElseThrow());
+
+        optionalWithDefaultMappingOptional =
+                optionalWithDefaultMappingOptionalDao.create(OptionalWithDefaultMappingOptional.builder().withAttr("initial").build());
+        assertEquals("initial", optionalWithDefaultMappingOptional.getAttr().orElseThrow());
+        assertEquals(2, optionalDao.query().count());
+        assertEquals(1, optionalDao.query().filterByAttr(StringFilter.equalTo("initial")).count());
+
+        optionalWithDefaultMappingOptional.setAttr("updated");
+        optionalWithDefaultMappingOptional = optionalWithDefaultMappingOptionalDao.update(optionalWithDefaultMappingOptional);
+        assertEquals("updated", optionalWithDefaultMappingOptional.getAttr().orElseThrow());
+        assertEquals(2, optionalDao.query().count());
+        assertEquals(1, optionalDao.query().filterByAttr(StringFilter.equalTo("updated")).count());
+        assertEquals(0, optionalDao.query().filterByAttr(StringFilter.equalTo("initial")).count());
+
+        optionalWithDefaultMappingOptional.setAttr(null);
+        optionalWithDefaultMappingOptional = optionalWithDefaultMappingOptionalDao.update(optionalWithDefaultMappingOptional);
+        assertTrue(optionalWithDefaultMappingOptional.getAttr().isEmpty());
+        assertEquals(2, optionalDao.query().count());
+        assertEquals(0, optionalDao.query().filterByAttr(StringFilter.equalTo("updated")).count());
     }
 
     @Test
     public void testRequiredMapping() {
+        ValidationException exception = assertThrows(ValidationException.class, () -> requiredMappingOptionalDao.create(RequiredMappingOptional.create()));
+        assertEquals(1, exception.getValidationResults().size());
+        ValidationResult validationResult = exception.getValidationResults().stream().findAny().orElseThrow();
+        assertEquals("MISSING_REQUIRED_ATTRIBUTE", validationResult.getCode());
+        assertEquals("attr", validationResult.getLocation());
+
+        RequiredMappingOptional requiredMappingOptional = requiredMappingOptionalDao.create(RequiredMappingOptional.builder().withAttr("initial").build());
+        assertEquals("initial", requiredMappingOptional.getAttr());
+        assertEquals(1, optionalDao.query().count());
+        assertEquals(1, optionalDao.query().filterByAttr(StringFilter.equalTo("initial")).count());
+
+        requiredMappingOptional.setAttr("updated");
+        requiredMappingOptional = requiredMappingOptionalDao.update(requiredMappingOptional);
+        assertEquals("updated", requiredMappingOptional.getAttr());
+        assertEquals(1, optionalDao.query().count());
+        assertEquals(1, optionalDao.query().filterByAttr(StringFilter.equalTo("updated")).count());
+        assertEquals(0, optionalDao.query().filterByAttr(StringFilter.equalTo("initial")).count());
+
+        requiredMappingOptional.setAttr(null);
+        final RequiredMappingOptional finalRequiredMappingOptional = requiredMappingOptional;
+        ValidationException exception1 = assertThrows(ValidationException.class, () -> requiredMappingOptionalDao.update(finalRequiredMappingOptional));
+        assertEquals(1, exception1.getValidationResults().size());
+        ValidationResult validationResult1 = exception1.getValidationResults().stream().findAny().orElseThrow();
+        assertEquals("MISSING_REQUIRED_ATTRIBUTE", validationResult1.getCode());
+        assertEquals("attr", validationResult1.getLocation());
+        assertEquals(1, optionalDao.query().count());
+        assertEquals(1, optionalDao.query().filterByAttr(StringFilter.equalTo("updated")).count());
     }
 
     @Test
     public void testRequiredWithDefaultMapping() {
+        RequiredWithDefaultMappingOptional requiredWithDefaultMappingOptional =
+                requiredWithDefaultMappingOptionalDao.create(RequiredWithDefaultMappingOptional.create());
+        assertEquals("RequiredWithDefaultMappingOptional", requiredWithDefaultMappingOptional.getAttr());
+        assertEquals(1, requiredWithDefaultMappingOptionalDao.countAll());
+        assertEquals("RequiredWithDefaultMappingOptional", requiredWithDefaultMappingOptionalDao.query().execute().get(0).getAttr());
+
+        requiredWithDefaultMappingOptional =
+                requiredWithDefaultMappingOptionalDao.create(RequiredWithDefaultMappingOptional.builder().withAttr("initial").build());
+        assertEquals("initial", requiredWithDefaultMappingOptional.getAttr());
+        assertEquals(2, optionalDao.query().count());
+        assertEquals(1, optionalDao.query().filterByAttr(StringFilter.equalTo("initial")).count());
+
+        requiredWithDefaultMappingOptional.setAttr("updated");
+        requiredWithDefaultMappingOptional = requiredWithDefaultMappingOptionalDao.update(requiredWithDefaultMappingOptional);
+        assertEquals("updated", requiredWithDefaultMappingOptional.getAttr());
+        assertEquals(2, optionalDao.query().count());
+        assertEquals(1, optionalDao.query().filterByAttr(StringFilter.equalTo("updated")).count());
+        assertEquals(0, optionalDao.query().filterByAttr(StringFilter.equalTo("initial")).count());
+
+        requiredWithDefaultMappingOptional.setAttr(null);
+        final RequiredWithDefaultMappingOptional finalRequiredWithDefaultMappingOptional = requiredWithDefaultMappingOptional;
+        ValidationException exception1 =
+                assertThrows(ValidationException.class, () -> requiredWithDefaultMappingOptionalDao.update(finalRequiredWithDefaultMappingOptional));
+        assertEquals(1, exception1.getValidationResults().size());
+        ValidationResult validationResult1 = exception1.getValidationResults().stream().findAny().orElseThrow();
+        assertEquals("MISSING_REQUIRED_ATTRIBUTE", validationResult1.getCode());
+        assertEquals("attr", validationResult1.getLocation());
+        assertEquals(2, optionalDao.query().count());
+        assertEquals(1, optionalDao.query().filterByAttr(StringFilter.equalTo("updated")).count());
     }
 
 }

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/PrimitiveAttributeMappingCombinations/OptionalTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/PrimitiveAttributeMappingCombinations/OptionalTest.java
@@ -1,0 +1,58 @@
+package hu.blackbelt.judo.runtime.core.jsl.transfer.PrimitiveAttributeMappingCombinations;
+
+/*-
+ * #%L
+ * JUDO Runtime Core JSL :: Parent
+ * %%
+ * Copyright (C) 2018 - 2022 BlackBelt Technology
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import com.google.inject.Module;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.guice.OptionalModelDaoModules;
+import hu.blackbelt.judo.runtime.core.jsl.AbstractJslTest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class OptionalTest extends AbstractJslTest {
+
+    @Override
+    public Module getModelDaoModule() {
+        return new OptionalModelDaoModules();
+    }
+
+    @Override
+    public String getModelName() {
+        return "OptionalModel";
+    }
+
+    @Test
+    public void testOptionalMapping() {
+    }
+
+    @Test
+    public void testOptionalWithDefaultMapping() {
+    }
+
+    @Test
+    public void testRequiredMapping() {
+    }
+
+    @Test
+    public void testRequiredWithDefaultMapping() {
+    }
+
+}

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/PrimitiveAttributeMappingCombinations/OptionalWithDefaultTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/PrimitiveAttributeMappingCombinations/OptionalWithDefaultTest.java
@@ -1,0 +1,58 @@
+package hu.blackbelt.judo.runtime.core.jsl.transfer.PrimitiveAttributeMappingCombinations;
+
+/*-
+ * #%L
+ * JUDO Runtime Core JSL :: Parent
+ * %%
+ * Copyright (C) 2018 - 2022 BlackBelt Technology
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import com.google.inject.Module;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.guice.OptionalWithDefaultModelDaoModules;
+import hu.blackbelt.judo.runtime.core.jsl.AbstractJslTest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class OptionalWithDefaultTest extends AbstractJslTest {
+
+    @Override
+    public Module getModelDaoModule() {
+        return new OptionalWithDefaultModelDaoModules();
+    }
+
+    @Override
+    public String getModelName() {
+        return "OptionalWithDefaultModel";
+    }
+
+    @Test
+    public void testOptionalMapping() {
+    }
+
+    @Test
+    public void testOptionalWithDefaultMapping() {
+    }
+
+    @Test
+    public void testRequiredMapping() {
+    }
+
+    @Test
+    public void testRequiredWithDefaultMapping() {
+    }
+
+}

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/PrimitiveAttributeMappingCombinations/RequiredTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/PrimitiveAttributeMappingCombinations/RequiredTest.java
@@ -1,0 +1,58 @@
+package hu.blackbelt.judo.runtime.core.jsl.transfer.PrimitiveAttributeMappingCombinations;
+
+/*-
+ * #%L
+ * JUDO Runtime Core JSL :: Parent
+ * %%
+ * Copyright (C) 2018 - 2022 BlackBelt Technology
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import com.google.inject.Module;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.guice.RequiredModelDaoModules;
+import hu.blackbelt.judo.runtime.core.jsl.AbstractJslTest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class RequiredTest extends AbstractJslTest {
+
+    @Override
+    public Module getModelDaoModule() {
+        return new RequiredModelDaoModules();
+    }
+
+    @Override
+    public String getModelName() {
+        return "RequiredModel";
+    }
+
+    @Test
+    public void testOptionalMapping() {
+    }
+
+    @Test
+    public void testOptionalWithDefaultMapping() {
+    }
+
+    @Test
+    public void testRequiredMapping() {
+    }
+
+    @Test
+    public void testRequiredWithDefaultMapping() {
+    }
+
+}

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/PrimitiveAttributeMappingCombinations/RequiredWithDefaultTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/PrimitiveAttributeMappingCombinations/RequiredWithDefaultTest.java
@@ -1,0 +1,58 @@
+package hu.blackbelt.judo.runtime.core.jsl.transfer.PrimitiveAttributeMappingCombinations;
+
+/*-
+ * #%L
+ * JUDO Runtime Core JSL :: Parent
+ * %%
+ * Copyright (C) 2018 - 2022 BlackBelt Technology
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import com.google.inject.Module;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.guice.RequiredWithDefaultModelDaoModules;
+import hu.blackbelt.judo.runtime.core.jsl.AbstractJslTest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class RequiredWithDefaultTest extends AbstractJslTest {
+
+    @Override
+    public Module getModelDaoModule() {
+        return new RequiredWithDefaultModelDaoModules();
+    }
+
+    @Override
+    public String getModelName() {
+        return "RequiredWithDefaultModel";
+    }
+
+    @Test
+    public void testOptionalMapping() {
+    }
+
+    @Test
+    public void testOptionalWithDefaultMapping() {
+    }
+
+    @Test
+    public void testRequiredMapping() {
+    }
+
+    @Test
+    public void testRequiredWithDefaultMapping() {
+    }
+
+}

--- a/judo-runtime-core-jsl-itest/src/test/resources/model/PrimitiveAttributeMappingCombinationsModel/Optional.jsl
+++ b/judo-runtime-core-jsl-itest/src/test/resources/model/PrimitiveAttributeMappingCombinationsModel/Optional.jsl
@@ -1,0 +1,31 @@
+model OptionalModel;
+
+import judo::types;
+
+entity Optional {
+    field String attr;
+}
+
+transfer OptionalMappingOptional(Optional o) {
+    field String attr maps o.attr;
+}
+
+transfer OptionalWithDefaultMappingOptional(Optional o) {
+    field String attr maps o.attr;
+
+    constructor {
+        self.attr = "OptionalWithDefaultMappingOptional";
+    }
+}
+
+transfer RequiredMappingOptional(Optional o) {
+    field required String attr maps o.attr;
+}
+
+transfer RequiredWithDefaultMappingOptional(Optional o) {
+    field required String attr maps o.attr;
+
+    constructor {
+        self.attr = "RequiredWithDefaultMappingOptional";
+    }
+}

--- a/judo-runtime-core-jsl-itest/src/test/resources/model/PrimitiveAttributeMappingCombinationsModel/OptionalWithDefault.jsl
+++ b/judo-runtime-core-jsl-itest/src/test/resources/model/PrimitiveAttributeMappingCombinationsModel/OptionalWithDefault.jsl
@@ -1,0 +1,31 @@
+model OptionalWithDefaultModel;
+
+import judo::types;
+
+entity OptionalWithDefault {
+    field String attr = "OptionalWithDefault";
+}
+
+transfer OptionalMappingOptionalWithDefault(OptionalWithDefault o) {
+    field String attr maps o.attr;
+}
+
+transfer OptionalWithDefaultMappingOptionalWithDefault(OptionalWithDefault o) {
+    field String attr maps o.attr;
+
+    constructor {
+        self.attr = "OptionalWithDefaultMappingOptionalWithDefault";
+    }
+}
+
+transfer RequiredMappingOptionalWithDefault(OptionalWithDefault o) {
+    field required String attr maps o.attr;
+}
+
+transfer RequiredWithDefaultMappingOptionalWithDefault(OptionalWithDefault o) {
+    field required String attr maps o.attr;
+
+    constructor {
+        self.attr = "RequiredWithDefaultMappingOptionalWithDefault";
+    }
+}

--- a/judo-runtime-core-jsl-itest/src/test/resources/model/PrimitiveAttributeMappingCombinationsModel/Required.jsl
+++ b/judo-runtime-core-jsl-itest/src/test/resources/model/PrimitiveAttributeMappingCombinationsModel/Required.jsl
@@ -1,0 +1,31 @@
+model RequiredModel;
+
+import judo::types;
+
+entity RequiredAttribute {
+    field required String attr;
+}
+
+transfer OptionalMappingRequired(RequiredAttribute ra) {
+    field String attr maps ra.attr;
+}
+
+transfer OptionalWithDefaultMappingRequired(RequiredAttribute ra) {
+    field String attr maps ra.attr;
+
+    constructor {
+        self.attr = "OptionalWithDefaultMappingRequired";
+    }
+}
+
+transfer RequiredMappingRequired(RequiredAttribute ra) {
+    field required String attr maps ra.attr;
+}
+
+transfer RequiredWithDefaultMappingRequired(RequiredAttribute ra) {
+    field required String attr maps ra.attr;
+
+    constructor {
+        self.attr = "RequiredWithDefaultMappingRequired";
+    }
+}

--- a/judo-runtime-core-jsl-itest/src/test/resources/model/PrimitiveAttributeMappingCombinationsModel/RequiredWithDefault.jsl
+++ b/judo-runtime-core-jsl-itest/src/test/resources/model/PrimitiveAttributeMappingCombinationsModel/RequiredWithDefault.jsl
@@ -1,0 +1,31 @@
+model RequiredWithDefaultModel;
+
+import judo::types;
+
+entity RequiredWithDefault {
+    field required String attr = "RequiredWithDefault";
+}
+
+transfer OptionalMappingRequiredWithDefault(RequiredWithDefault r) {
+    field String attr maps r.attr;
+}
+
+transfer OptionalWithDefaultMappingRequiredWithDefault(RequiredWithDefault r) {
+    field String attr maps r.attr;
+
+    constructor {
+        self.attr = "OptionalWithDefaultMappingRequiredWithDefault";
+    }
+}
+
+transfer RequiredMappingRequiredWithDefault(RequiredWithDefault r) {
+    field required String attr maps r.attr;
+}
+
+transfer RequiredWithDefaultMappingRequiredWithDefault(RequiredWithDefault r) {
+    field required String attr maps r.attr;
+
+    constructor {
+        self.attr = "RequiredWithDefaultMappingRequiredWithDefault";
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4888" title="JNG-4888" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4888</a>  Mapped transfer object instantiation fails if both mapping and mapped attributes are required
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
