### PR TITLE
JNG-4917 fix Transfer automap maps the query members as a relation member

### DIFF
--- a/judo-runtime-core-jsl-itest/.classpath
+++ b/judo-runtime-core-jsl-itest/.classpath
@@ -246,20 +246,6 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/sdk-core/MappedTransferAssociation">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/sdk-core/MappedTransferAggregation">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/sdk-core/TransferConstructor">
 		<attributes>
 			<attribute name="optional" value="true"/>
@@ -282,6 +268,34 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/sdk-core/EntityWithSameQueryName">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/sdk-core/MappedTransferAssociationAggregation">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/sdk-core/MappedTransferCompositonAggregation">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/sdk-core/MappedTransferAssociationAssociation">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/sdk-core/TestDefaultAndRequiredFieldsOnMappedTO">
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/AutoMappedTransferObjectSingleEntityTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/AutoMappedTransferObjectSingleEntityTest.java
@@ -328,7 +328,6 @@ public class AutoMappedTransferObjectSingleEntityTest extends AbstractJslTest {
         );
 
         //TODO JNG-4906
-        //TODO JNG-4917
         autoMappedContainerSingleRelationDerivedEntityDao.create(AutoMappedContainerSingleRelationDerivedEntity.builder().build(),
                 AutoMappedContainerSingleRelationDerivedEntityAttachedRelationsForCreate.builder().build());
 

--- a/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/AutoMappedTransferObjectSingleEntityTest.java
+++ b/judo-runtime-core-jsl-itest/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/AutoMappedTransferObjectSingleEntityTest.java
@@ -329,8 +329,8 @@ public class AutoMappedTransferObjectSingleEntityTest extends AbstractJslTest {
 
         //TODO JNG-4906
         //TODO JNG-4917
-//        autoMappedContainerSingleRelationDerivedEntityDao.create(AutoMappedContainerSingleRelationDerivedEntity.builder().build(),
-//                AutoMappedContainerSingleRelationDerivedEntityAttachedRelationsForCreate.builder()..build());
+        autoMappedContainerSingleRelationDerivedEntityDao.create(AutoMappedContainerSingleRelationDerivedEntity.builder().build(),
+                AutoMappedContainerSingleRelationDerivedEntityAttachedRelationsForCreate.builder().build());
 
     }
 

--- a/judo-runtime-core-jsl-itest/src/test/resources/model/AutoMappedTransferSingleEntityModel/AutoMappedTransferSingleEntity.jsl
+++ b/judo-runtime-core-jsl-itest/src/test/resources/model/AutoMappedTransferSingleEntityModel/AutoMappedTransferSingleEntity.jsl
@@ -55,6 +55,8 @@ transfer AutoMappedContainerSingleCompositionDerivedEntity(ContainerSingleCompos
 
 query ReferenceEntity referenceEntityWithNameQuery(String name) <= ReferenceEntity!all()!filter(e | e.name == name)!any();
 
+query Integer countReferenceEntityWithNameQuery(String name) <= ReferenceEntity!all()!filter(e | e.name == name)!size();
+
 entity ContainerSingleRelationDerivedEntity {
 
     relation ReferenceEntity singleComposition;
@@ -68,6 +70,9 @@ entity ContainerSingleRelationDerivedEntity {
 
     @Query
     relation ReferenceEntity singleRelationEntityExpressionQuery(String name) <= referenceEntityWithNameQuery(name = name);
+
+    @Query
+    field Integer primitiveQuery(String name) <= countReferenceEntityWithNameQuery(name = name);
 
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
             javax.transaction.xa;version=!,
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
-        <judo-tatami-jsl-version>1.1.4.20230630_040722_4c0cc912_develop</judo-tatami-jsl-version>
+        <judo-tatami-jsl-version>1.1.4.20230630_121936_91af789a_featuer_JNG_4917_transfer_automap_maps_the_query_members_as_relation_member</judo-tatami-jsl-version>
         <judo-runtime-core-version>1.0.6.20230612_194236_d0b700db_develop</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230627_171729_6351028c_develop</judo-psm-generator-sdk-core-version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         </osgi-transaction-import>
         <judo-tatami-jsl-version>1.1.4.20230630_125842_9d41f3b0_featuer_JNG_4917_transfer_automap_maps_the_query_members_as_relation_member</judo-tatami-jsl-version>
         <judo-runtime-core-version>1.0.6.20230612_194236_d0b700db_develop</judo-runtime-core-version>
-        <judo-psm-generator-sdk-core-version>1.0.0.20230630_140959_3de57ce1_featuer_JNG_4917_transfer_automap_maps_the_query_members_as_relation_member</judo-psm-generator-sdk-core-version>
+        <judo-psm-generator-sdk-core-version>1.0.0.20230703_075153_23ac05d1_featuer_JNG_4917_transfer_automap_maps_the_query_members_as_relation_member</judo-psm-generator-sdk-core-version>
 
         <judo-meta-psm-version>1.3.0.20230516_100351_2fb48f5a_develop</judo-meta-psm-version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@
             javax.transaction.xa;version=!,
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
-        <judo-tatami-jsl-version>1.1.4.20230630_121936_91af789a_featuer_JNG_4917_transfer_automap_maps_the_query_members_as_relation_member</judo-tatami-jsl-version>
+        <judo-tatami-jsl-version>1.1.4.20230630_125842_9d41f3b0_featuer_JNG_4917_transfer_automap_maps_the_query_members_as_relation_member</judo-tatami-jsl-version>
         <judo-runtime-core-version>1.0.6.20230612_194236_d0b700db_develop</judo-runtime-core-version>
-        <judo-psm-generator-sdk-core-version>1.0.0.20230627_171729_6351028c_develop</judo-psm-generator-sdk-core-version>
+        <judo-psm-generator-sdk-core-version>1.0.0.20230630_133544_0c12a82c_featuer_JNG_4917_transfer_automap_maps_the_query_members_as_relation_member</judo-psm-generator-sdk-core-version>
 
         <judo-meta-psm-version>1.3.0.20230516_100351_2fb48f5a_develop</judo-meta-psm-version>
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4917" title="JNG-4917" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4917</a>  Transfer automap maps the query members as a relation member
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

