### PR TITLE
JNG-4356 Unmapped transfer throws validation error to mapped transfer mandatory attributes

### DIFF
--- a/judo-runtime-core-jsl-itest/models/EntityRelationshipsModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/entity/AssociationRelationshipsTest.java
+++ b/judo-runtime-core-jsl-itest/models/EntityRelationshipsModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/entity/AssociationRelationshipsTest.java
@@ -38,8 +38,10 @@ import hu.blackbelt.judo.psm.generator.sdk.core.test.api.associationrelationship
 import hu.blackbelt.judo.psm.generator.sdk.core.test.guice.AssociationRelationshipsDaoModules;
 import hu.blackbelt.judo.requirement.report.annotation.Requirement;
 import hu.blackbelt.judo.requirement.report.annotation.TestCase;
+import hu.blackbelt.judo.runtime.core.exception.ValidationException;
 import hu.blackbelt.judo.runtime.core.jsl.fixture.JudoRuntimeExtension;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -48,7 +50,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
@@ -209,13 +211,16 @@ public class AssociationRelationshipsTest {
             "REQ-ENT-012"
     })
     public void testRequiredRelationEnforced() {
-        IllegalArgumentException thrown = assertThrows(
-                IllegalArgumentException.class,
+        ValidationException thrown = assertThrows(
+                ValidationException.class,
                 () -> entityADao.create(EntityA.builder().build())
         );
 
-        assertTrue(thrown.getMessage().contains("missing mandatory attribute"));
-        assertTrue(thrown.getMessage().contains("name: singleRequiredConA"));
+        Assertions.assertEquals(1, thrown.getValidationResults().size());
+        assertThat(thrown.getValidationResults(), containsInAnyOrder(allOf(
+                hasProperty("code", equalTo("MISSING_REQUIRED_RELATION")),
+                hasProperty("location", equalTo("singleRequiredConA")))
+        ));
 
         List<EntityA> list = entityADao.query().execute();
 

--- a/judo-runtime-core-jsl-itest/models/TransferAssociationModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/MappedTransferAssociationAssociationTest.java
+++ b/judo-runtime-core-jsl-itest/models/TransferAssociationModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/MappedTransferAssociationAssociationTest.java
@@ -21,6 +21,7 @@ package hu.blackbelt.judo.runtime.core.jsl.transfer;
  */
 
 import com.google.inject.Inject;
+import hu.blackbelt.judo.dao.api.ValidationResult;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.mappedtransferassociationassociation.mappedtransferassociationassociation.entitya.EntityA;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.mappedtransferassociationassociation.mappedtransferassociationassociation.entitya.EntityADao;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.mappedtransferassociationassociation.mappedtransferassociationassociation.entitya.EntityAIdentifier;
@@ -91,6 +92,7 @@ import hu.blackbelt.judo.psm.generator.sdk.core.test.api.mappedtransferassociati
 import hu.blackbelt.judo.psm.generator.sdk.core.test.guice.MappedTransferAssociationAssociationDaoModules;
 import hu.blackbelt.judo.requirement.report.annotation.Requirement;
 import hu.blackbelt.judo.requirement.report.annotation.TestCase;
+import hu.blackbelt.judo.runtime.core.exception.ValidationException;
 import hu.blackbelt.judo.runtime.core.jsl.fixture.JudoRuntimeExtension;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
@@ -103,7 +105,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
@@ -330,13 +333,16 @@ public class MappedTransferAssociationAssociationTest {
 
         //creation without mandatory element
 
-        IllegalArgumentException thrown1 = assertThrows(
-                IllegalArgumentException.class,
+        ValidationException thrown1 = assertThrows(
+                ValidationException.class,
                 () -> transferCDao.create(TransferC.builder().build())
         );
 
-        assertTrue(thrown1.getMessage().contains("There is missing mandatory attribute/reference"));
-        assertTrue(thrown1.getMessage().contains("relationDonC"));
+        assertEquals(1, thrown1.getValidationResults().size());
+        assertThat(thrown1.getValidationResults(), containsInAnyOrder(allOf(
+                hasProperty("code", equalTo("MISSING_REQUIRED_RELATION")),
+                hasProperty("location", equalTo("relationDonC")))
+        ));
 
         // Test dao set, unset
         transferCDao.setRelationDonC(transferC, td1);

--- a/judo-runtime-core-jsl-itest/models/TransferAssociationModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/MappedTransferCompositonAssociationTest.java
+++ b/judo-runtime-core-jsl-itest/models/TransferAssociationModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/MappedTransferCompositonAssociationTest.java
@@ -41,8 +41,10 @@ import hu.blackbelt.judo.psm.generator.sdk.core.test.api.mappedtransfercomposito
 import hu.blackbelt.judo.psm.generator.sdk.core.test.guice.MappedTransferCompositonAssociationDaoModules;
 import hu.blackbelt.judo.requirement.report.annotation.Requirement;
 import hu.blackbelt.judo.requirement.report.annotation.TestCase;
+import hu.blackbelt.judo.runtime.core.exception.ValidationException;
 import hu.blackbelt.judo.runtime.core.jsl.fixture.JudoRuntimeExtension;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -50,7 +52,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -202,13 +205,16 @@ public class MappedTransferCompositonAssociationTest {
 //        assertEquals(2,entityDDao.query().execute().size());
 
         //Try to create without required element
-        IllegalArgumentException thrown = assertThrows(
-                IllegalArgumentException.class,
+        ValidationException thrown = assertThrows(
+                ValidationException.class,
                 () -> transferCDao.create(TransferC.builder().build())
         );
 
-        assertTrue(thrown.getMessage().contains("There is missing mandatory attribute/reference on"));
-        assertTrue(thrown.getMessage().contains("singleRequiredEntityD"));
+        Assertions.assertEquals(1, thrown.getValidationResults().size());
+        assertThat(thrown.getValidationResults(), containsInAnyOrder(allOf(
+                hasProperty("code", equalTo("MISSING_REQUIRED_RELATION")),
+                hasProperty("location", equalTo("singleRequiredEntityD")))
+        ));
 
         //Try to delete the required element
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
 
-        <judo-tatami-jsl-version>1.1.4.20230914_202118_0fe18c2a_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230914_150032_a1e30a3b_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230918_102727_5d3cd936_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230918_101554_91de931c_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230914_120625_a6090a2b_develop</judo-psm-generator-sdk-core-version>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
 
         <judo-meta-psm-version>1.3.0.20230907_041147_fd92c63a_develop</judo-meta-psm-version>
 
+        
         <!-- Code Quality-->
         <sonar-maven-plugin-version>3.9.1.2184</sonar-maven-plugin-version>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
 
-        <judo-tatami-jsl-version>1.1.4.20230913_085423_54747c08_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230913_082338_96096e3d_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230914_202118_0fe18c2a_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230914_150032_a1e30a3b_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230912_041701_9f49da18_develop</judo-psm-generator-sdk-core-version>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
 
-        <judo-tatami-jsl-version>1.1.4.20230911_123946_ee32259e_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230911_122943_c9e69af6_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230913_085423_54747c08_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230913_082338_96096e3d_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230912_041701_9f49da18_develop</judo-psm-generator-sdk-core-version>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
 
-        <judo-tatami-jsl-version>1.1.4.20230911_114609_b8dd17a2_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230911_092409_666cd758_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230911_123946_ee32259e_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230911_122943_c9e69af6_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230908_041138_521e5276_develop</judo-psm-generator-sdk-core-version>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
 
-        <judo-tatami-jsl-version>1.1.4.20230908_041839_10c88936_develop</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230908_041501_71f3fbb9_develop</judo-runtime-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230911_114609_b8dd17a2_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230911_092409_666cd758_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230908_041138_521e5276_develop</judo-psm-generator-sdk-core-version>
 
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4356" title="JNG-4356" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4356</a>  Aggragated mapped transfer object from unmapped transfer object with mandatory parameters throws validation error on operation call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

JNG-4356 Unmapped transfer throws validation error to mapped transfer mandatory attributes