### PR TITLE
JNG-5089 the payload not contains the recursive single relation on the sublevels

### DIFF
--- a/judo-runtime-core-jsl-itest/models/RecursiveCompositionModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/entity/entity/RecursiveCompositionTest.java
+++ b/judo-runtime-core-jsl-itest/models/RecursiveCompositionModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/entity/entity/RecursiveCompositionTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -69,8 +70,7 @@ public class RecursiveCompositionTest {
             "REQ-ENT-001",
             "REQ-ENT-002",
             "REQ-ENT-004",
-            "REQ-ENT-005",
-            "REQ-SRV-001"
+            "REQ-ENT-007",
     })
     void testRecursiveCompositionOnEntity() {
 
@@ -185,8 +185,7 @@ public class RecursiveCompositionTest {
             "REQ-ENT-001",
             "REQ-ENT-002",
             "REQ-ENT-004",
-            "REQ-ENT-005",
-            "REQ-SRV-001"
+            "REQ-ENT-007"
     })
     void testRecursiveCompositionOnInheritedEntity() {
 
@@ -228,6 +227,23 @@ public class RecursiveCompositionTest {
     }
 
     @Test
+    @Requirement(reqs = {
+            "REQ-MDL-001",
+            "REQ-MDL-002",
+            "REQ-MDL-003",
+            "REQ-TYPE-001",
+            "REQ-TYPE-004",
+            "REQ-ENT-001",
+            "REQ-ENT-002",
+            "REQ-ENT-004",
+            "REQ-ENT-007",
+            "REQ-ENT-008",
+            "REQ-EXPR-001",
+            "REQ-EXPR-002",
+            "REQ-EXPR-003",
+            "REQ-EXPR-004",
+            "REQ-EXPR-012"
+    })
     void testForMultiLevelSingleComposition() {
 
         EntityA a = entityADao.create(EntityA.builder().withName("level1")
@@ -240,29 +256,35 @@ public class RecursiveCompositionTest {
 
         assertEquals(4, entityADao.countAll());
 
-        assertEquals(a.getA().get().getName().get(),"level2");
-        assertEquals(a.getA().get().getA().get().getName().get(),"level3");
-        assertEquals(a.getA().get().getA().get().getA().get().getName().get(),"level4");
+        assertEquals("level2", a.getA().get().getName().get());
+        assertEquals("level3", a.getA().get().getA().get().getName().get());
+        assertEquals("level4", a.getA().get().getA().get().getA().get().getName().get());
 
         // childName with derived
-        assertEquals(a.getChildName().get(),"level2");
-        assertEquals(a.getA().get().getChildName().get(),"level3");
-        assertEquals(a.getA().get().getA().get().getChildName().get(),"level4");
-        assertEquals(a.getA().get().getA().get().getA().get().getChildName().get(),"");
+        assertEquals("level2", a.getChildName().get());
+        assertEquals("level3", a.getA().get().getChildName().get());
+        assertEquals("level4", a.getA().get().getA().get().getChildName().get());
+        assertEquals("", a.getA().get().getA().get().getA().get().getChildName().get());
 
+        // recursive navigation through derived
+        assertEquals("level3", a.getChildNameThirdLevel().get());
+        assertEquals("level4", a.getChildNameFourthLevel().get());
 
         // After update
         a = entityADao.update(a);
-        assertEquals(a.getA().get().getName().get(),"level2");
-        assertEquals(a.getA().get().getA().get().getName().get(),"level3");
-        assertEquals(a.getA().get().getA().get().getA().get().getName().get(),"level4");
+        assertEquals("level2", a.getA().get().getName().get());
+        assertEquals("level3", a.getA().get().getA().get().getName().get());
+        assertEquals("level4", a.getA().get().getA().get().getA().get().getName().get());
 
         // childName with derived
-        assertEquals(a.getChildName().get(),"level2");
-        assertEquals(a.getA().get().getChildName().get(),"level3");
-        assertEquals(a.getA().get().getA().get().getChildName().get(),"level4");
-        assertEquals(a.getA().get().getA().get().getA().get().getChildName().get(),"");
+        assertEquals("level2", a.getChildName().get());
+        assertEquals("level3", a.getA().get().getChildName().get());
+        assertEquals("level4", a.getA().get().getA().get().getChildName().get());
+        assertEquals("", a.getA().get().getA().get().getA().get().getChildName().get());
 
+        // recursive navigation through derived
+        assertEquals("level3", a.getChildNameThirdLevel().get());
+        assertEquals("level4", a.getChildNameFourthLevel().get());
 
         // Remove element
         a.getA().orElseThrow().getA().orElseThrow().setA(null);
@@ -270,18 +292,39 @@ public class RecursiveCompositionTest {
 
         assertEquals(3, entityADao.countAll());
 
-        assertEquals(a.getA().get().getName().get(),"level2");
-        assertEquals(a.getA().get().getA().get().getName().get(),"level3");
+        assertEquals("level2", a.getA().get().getName().get());
+        assertEquals("level3", a.getA().get().getA().get().getName().get());
         assertTrue(a.getA().get().getA().get().getA().isEmpty());
 
         // childName with derived
-        assertEquals(a.getChildName().get(),"level2");
-        assertEquals(a.getA().get().getChildName().get(),"level3");
-        assertEquals(a.getA().get().getA().get().getChildName().get(),"");
+        assertEquals("level2", a.getChildName().get());
+        assertEquals("level3", a.getA().get().getChildName().get());
+        assertEquals("", a.getA().get().getA().get().getChildName().get());
 
+        // recursive navigation through derived
+        assertEquals("level3", a.getChildNameThirdLevel().orElseThrow());
+        assertEquals(Optional.empty(), a.getChildNameFourthLevel());
     }
 
     @Test
+    @Requirement(reqs = {
+            "REQ-MDL-001",
+            "REQ-MDL-002",
+            "REQ-MDL-003",
+            "REQ-TYPE-001",
+            "REQ-TYPE-004",
+            "REQ-ENT-001",
+            "REQ-ENT-002",
+            "REQ-ENT-004",
+            "REQ-ENT-007",
+            "REQ-ENT-008",
+            "REQ-ENT-012",
+            "REQ-EXPR-001",
+            "REQ-EXPR-002",
+            "REQ-EXPR-003",
+            "REQ-EXPR-004",
+            "REQ-EXPR-012"
+    })
     void testForInheritedMultiLevelSingleComposition() {
 
         EntityB b = entityBDao.create(EntityB.builder().withName("level1")
@@ -301,39 +344,51 @@ public class RecursiveCompositionTest {
         assertEquals(7, entityADao.countAll());
         assertEquals(1, entityBDao.countAll());
 
-        assertEquals(b.getA().get().getName().get(),"level2");
-        assertEquals(b.getA().get().getA().get().getName().get(),"level3");
-        assertEquals(b.getA().get().getA().get().getA().get().getName().get(),"level4");
-        assertEquals(b.getBa().get().getName().get(),"level2");
-        assertEquals(b.getBa().get().getA().get().getName().get(),"level3");
-        assertEquals(b.getBa().get().getA().get().getA().get().getName().get(),"level4");
+        assertEquals("level2", b.getA().get().getName().get());
+        assertEquals("level3", b.getA().get().getA().get().getName().get());
+        assertEquals("level4", b.getA().get().getA().get().getA().get().getName().get());
+        assertEquals("level2", b.getBa().get().getName().get());
+        assertEquals("level3", b.getBa().get().getA().get().getName().get());
+        assertEquals("level4", b.getBa().get().getA().get().getA().get().getName().get());
 
         // childName with derived
-        assertEquals(b.getChildName().get(),"level2");
-        assertEquals(b.getA().get().getChildName().get(),"level3");
-        assertEquals(b.getA().get().getA().get().getChildName().get(),"level4");
-        assertEquals(b.getA().get().getA().get().getA().get().getChildName().get(),"");
-        assertEquals(b.getBa().get().getChildName().get(),"level3");
-        assertEquals(b.getBa().get().getA().get().getChildName().get(),"level4");
-        assertEquals(b.getBa().get().getA().get().getA().get().getChildName().get(),"");
+        assertEquals("level2", b.getChildName().get());
+        assertEquals("level3", b.getA().get().getChildName().get());
+        assertEquals("level4", b.getA().get().getA().get().getChildName().get());
+        assertEquals("", b.getA().get().getA().get().getA().get().getChildName().get());
+        assertEquals("level3", b.getBa().get().getChildName().get());
+        assertEquals("level4", b.getBa().get().getA().get().getChildName().get());
+        assertEquals("", b.getBa().get().getA().get().getA().get().getChildName().get());
+
+        // recursive navigation through derived
+        assertEquals("level3", b.getChildNameThirdLevel().get());
+        assertEquals("level4", b.getChildNameFourthLevel().get());
+        assertEquals("level4", b.getBa().get().getChildNameThirdLevel().get());
+        assertEquals(Optional.empty(), b.getBa().get().getChildNameFourthLevel());
 
         // After update
         b = entityBDao.update(b);
-        assertEquals(b.getA().get().getName().get(),"level2");
-        assertEquals(b.getA().get().getA().get().getName().get(),"level3");
-        assertEquals(b.getA().get().getA().get().getA().get().getName().get(),"level4");
-        assertEquals(b.getBa().get().getName().get(),"level2");
-        assertEquals(b.getBa().get().getA().get().getName().get(),"level3");
-        assertEquals(b.getBa().get().getA().get().getA().get().getName().get(),"level4");
+        assertEquals("level2", b.getA().get().getName().get());
+        assertEquals("level3", b.getA().get().getA().get().getName().get());
+        assertEquals("level4", b.getA().get().getA().get().getA().get().getName().get());
+        assertEquals("level2", b.getBa().get().getName().get());
+        assertEquals("level3", b.getBa().get().getA().get().getName().get());
+        assertEquals("level4", b.getBa().get().getA().get().getA().get().getName().get());
 
         // childName with derived
-        assertEquals(b.getChildName().get(),"level2");
-        assertEquals(b.getA().get().getChildName().get(),"level3");
-        assertEquals(b.getA().get().getA().get().getChildName().get(),"level4");
-        assertEquals(b.getA().get().getA().get().getA().get().getChildName().get(),"");
-        assertEquals(b.getBa().get().getChildName().get(),"level3");
-        assertEquals(b.getBa().get().getA().get().getChildName().get(),"level4");
-        assertEquals(b.getBa().get().getA().get().getA().get().getChildName().get(),"");
+        assertEquals("level2", b.getChildName().get());
+        assertEquals("level3", b.getA().get().getChildName().get());
+        assertEquals("level4", b.getA().get().getA().get().getChildName().get());
+        assertEquals("", b.getA().get().getA().get().getA().get().getChildName().get());
+        assertEquals("level3", b.getBa().get().getChildName().get());
+        assertEquals("level4", b.getBa().get().getA().get().getChildName().get());
+        assertEquals("", b.getBa().get().getA().get().getA().get().getChildName().get());
+
+        // recursive navigation through derived
+        assertEquals("level3", b.getChildNameThirdLevel().get());
+        assertEquals("level4", b.getChildNameFourthLevel().get());
+        assertEquals("level4", b.getBa().get().getChildNameThirdLevel().get());
+        assertEquals(Optional.empty(), b.getBa().get().getChildNameFourthLevel());
 
         // Remove element
         b.getA().orElseThrow().getA().orElseThrow().setA(null);
@@ -343,20 +398,25 @@ public class RecursiveCompositionTest {
         assertEquals(5, entityADao.countAll());
         assertEquals(1, entityBDao.countAll());
 
-        assertEquals(b.getA().get().getName().get(),"level2");
-        assertEquals(b.getA().get().getA().get().getName().get(),"level3");
+        assertEquals("level2", b.getA().get().getName().get());
+        assertEquals("level3", b.getA().get().getA().get().getName().get());
         assertTrue(b.getA().get().getA().get().getA().isEmpty());
-        assertEquals(b.getBa().get().getName().get(),"level2");
-        assertEquals(b.getBa().get().getA().get().getName().get(),"level3");
+        assertEquals("level2", b.getBa().get().getName().get());
+        assertEquals("level3", b.getBa().get().getA().get().getName().get());
         assertTrue(b.getBa().get().getA().get().getA().isEmpty());
 
         // childName with derived
-        assertEquals(b.getChildName().get(),"level2");
-        assertEquals(b.getA().get().getChildName().get(),"level3");
-        assertEquals(b.getA().get().getA().get().getChildName().get(),"");
-        assertEquals(b.getBa().get().getChildName().get(),"level3");
-        assertEquals(b.getBa().get().getA().get().getChildName().get(),"");
+        assertEquals("level2", b.getChildName().get());
+        assertEquals("level3", b.getA().get().getChildName().get());
+        assertEquals("", b.getA().get().getA().get().getChildName().get());
+        assertEquals("level3", b.getBa().get().getChildName().get());
+        assertEquals("", b.getBa().get().getA().get().getChildName().get());
 
+        // recursive navigation through derived
+        assertEquals("level3", b.getChildNameThirdLevel().get());
+        assertEquals(Optional.empty(), b.getChildNameFourthLevel());
+        assertEquals(Optional.empty(), b.getBa().get().getChildNameThirdLevel());
+        assertEquals(Optional.empty(), b.getBa().get().getChildNameFourthLevel());
 
     }
 }

--- a/judo-runtime-core-jsl-itest/models/RecursiveCompositionModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/entity/mappedto/RecursiveCompositionTest.java
+++ b/judo-runtime-core-jsl-itest/models/RecursiveCompositionModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/entity/mappedto/RecursiveCompositionTest.java
@@ -358,4 +358,136 @@ public class RecursiveCompositionTest {
         assertTrue(a3TransferATO.getAs().stream().anyMatch(c -> "a5".equals(c.getName().orElseThrow())));
         assertTrue(a3TransferATO.getAs().stream().anyMatch(c -> "a6".equals(c.getName().orElseThrow())));
     }
+
+
+    @Test
+    void testForMultiLevelSingleComposition() {
+
+        TransferATO a = transferATODao.create(TransferATO.builder().withName("level1")
+                .withA(TransferATO.builder().withName("level2")
+                        .withA(TransferATO.builder().withName("level3")
+                                .withA(TransferATO.builder().withName("level4").build()).build()
+                        ).build()
+                ).build()
+        );
+
+        assertEquals(4, transferATODao.countAll());
+
+        assertEquals(a.getA().get().getName().get(),"level2");
+        assertEquals(a.getA().get().getA().get().getName().get(),"level3");
+        assertEquals(a.getA().get().getA().get().getA().get().getName().get(),"level4");
+
+        // childName with derived
+        assertEquals(a.getChildName().get(),"level2");
+        assertEquals(a.getA().get().getChildName().get(),"level3");
+        assertEquals(a.getA().get().getA().get().getChildName().get(),"level4");
+        assertEquals(a.getA().get().getA().get().getA().get().getChildName().get(),"");
+
+
+        // After update
+        a = transferATODao.update(a);
+        assertEquals(a.getA().get().getName().get(),"level2");
+        assertEquals(a.getA().get().getA().get().getName().get(),"level3");
+        assertEquals(a.getA().get().getA().get().getA().get().getName().get(),"level4");
+
+        // childName with derived
+        assertEquals(a.getChildName().get(),"level2");
+        assertEquals(a.getA().get().getChildName().get(),"level3");
+        assertEquals(a.getA().get().getA().get().getChildName().get(),"level4");
+        assertEquals(a.getA().get().getA().get().getA().get().getChildName().get(),"");
+
+        // Remove element
+        a.getA().orElseThrow().getA().orElseThrow().setA(null);
+        a = transferATODao.update(a);
+
+        assertEquals(3, transferATODao.countAll());
+
+        assertEquals(a.getA().get().getName().get(),"level2");
+        assertEquals(a.getA().get().getA().get().getName().get(),"level3");
+        assertTrue(a.getA().get().getA().get().getA().isEmpty());
+
+        // childName with derived
+        assertEquals(a.getChildName().get(),"level2");
+        assertEquals(a.getA().get().getChildName().get(),"level3");
+        assertEquals(a.getA().get().getA().get().getChildName().get(),"");
+
+    }
+
+    @Test
+    void testForInheritedMultiLevelSingleComposition() {
+
+        TransferBTO b = transferBTODao.create(TransferBTO.builder().withName("level1")
+                .withA(TransferATO.builder().withName("level2")
+                        .withA(TransferATO.builder().withName("level3")
+                                .withA(TransferATO.builder().withName("level4").build()).build()
+                        ).build()
+                )
+                .withBa(TransferATO.builder().withName("level2")
+                        .withA(TransferATO.builder().withName("level3")
+                                .withA(TransferATO.builder().withName("level4").build()).build()
+                        ).build()
+                )
+                .build()
+        );
+
+        assertEquals(7, transferATODao.countAll());
+        assertEquals(1, transferBTODao.countAll());
+
+        assertEquals(b.getA().get().getName().get(),"level2");
+        assertEquals(b.getA().get().getA().get().getName().get(),"level3");
+        assertEquals(b.getA().get().getA().get().getA().get().getName().get(),"level4");
+        assertEquals(b.getBa().get().getName().get(),"level2");
+        assertEquals(b.getBa().get().getA().get().getName().get(),"level3");
+        assertEquals(b.getBa().get().getA().get().getA().get().getName().get(),"level4");
+
+        // childName with derived
+        assertEquals(b.getChildName().get(),"level2");
+        assertEquals(b.getA().get().getChildName().get(),"level3");
+        assertEquals(b.getA().get().getA().get().getChildName().get(),"level4");
+        assertEquals(b.getA().get().getA().get().getA().get().getChildName().get(),"");
+        assertEquals(b.getBa().get().getChildName().get(),"level3");
+        assertEquals(b.getBa().get().getA().get().getChildName().get(),"level4");
+        assertEquals(b.getBa().get().getA().get().getA().get().getChildName().get(),"");
+
+        // After update
+        b = transferBTODao.update(b);
+        assertEquals(b.getA().get().getName().get(),"level2");
+        assertEquals(b.getA().get().getA().get().getName().get(),"level3");
+        assertEquals(b.getA().get().getA().get().getA().get().getName().get(),"level4");
+        assertEquals(b.getBa().get().getName().get(),"level2");
+        assertEquals(b.getBa().get().getA().get().getName().get(),"level3");
+        assertEquals(b.getBa().get().getA().get().getA().get().getName().get(),"level4");
+
+        // childName with derived
+        assertEquals(b.getChildName().get(),"level2");
+        assertEquals(b.getA().get().getChildName().get(),"level3");
+        assertEquals(b.getA().get().getA().get().getChildName().get(),"level4");
+        assertEquals(b.getA().get().getA().get().getA().get().getChildName().get(),"");
+        assertEquals(b.getBa().get().getChildName().get(),"level3");
+        assertEquals(b.getBa().get().getA().get().getChildName().get(),"level4");
+        assertEquals(b.getBa().get().getA().get().getA().get().getChildName().get(),"");
+
+        // Remove element
+        b.getA().orElseThrow().getA().orElseThrow().setA(null);
+        b.getBa().orElseThrow().getA().orElseThrow().setA(null);
+        b = transferBTODao.update(b);
+
+        assertEquals(5, transferATODao.countAll());
+        assertEquals(1, transferBTODao.countAll());
+
+        assertEquals(b.getA().get().getName().get(),"level2");
+        assertEquals(b.getA().get().getA().get().getName().get(),"level3");
+        assertTrue(b.getA().get().getA().get().getA().isEmpty());
+        assertEquals(b.getBa().get().getName().get(),"level2");
+        assertEquals(b.getBa().get().getA().get().getName().get(),"level3");
+        assertTrue(b.getBa().get().getA().get().getA().isEmpty());
+
+        // childName with derived
+        assertEquals(b.getChildName().get(),"level2");
+        assertEquals(b.getA().get().getChildName().get(),"level3");
+        assertEquals(b.getA().get().getA().get().getChildName().get(),"");
+        assertEquals(b.getBa().get().getChildName().get(),"level3");
+        assertEquals(b.getBa().get().getA().get().getChildName().get(),"");
+
+    }
 }

--- a/judo-runtime-core-jsl-itest/models/RecursiveCompositionModel/src/test/resources/RecursiveComposition.jsl
+++ b/judo-runtime-core-jsl-itest/models/RecursiveCompositionModel/src/test/resources/RecursiveComposition.jsl
@@ -44,6 +44,7 @@ entity EntityA {
     field String name;
     field EntityA a;
     field EntityA[] as;
+    field String childName <= self.a!isDefined() ? self.a.name : "";
 }
 
 entity EntityB extends EntityA {
@@ -57,6 +58,9 @@ transfer TransferATO (EntityA entityA) {
     relation TransferATO a <=> entityA.a;
     @Embedded
     relation TransferATO[] as <=> entityA.as;
+
+    field String childName <= entityA.a!isDefined() ? entityA.a.name : "";
+
 }
 
 transfer TransferBTO (EntityB entityB) {
@@ -69,6 +73,8 @@ transfer TransferBTO (EntityB entityB) {
     relation TransferATO ba <=> entityB.ba;
     @Embedded
     relation TransferATO[] bas <=> entityB.bas;
+
+    field String childName <= entityB.a!isDefined() ? entityB.a.name : "";
 }
 
 transfer TransferAAutoMappedTO (EntityA entityA);

--- a/judo-runtime-core-jsl-itest/models/RecursiveCompositionModel/src/test/resources/RecursiveComposition.jsl
+++ b/judo-runtime-core-jsl-itest/models/RecursiveCompositionModel/src/test/resources/RecursiveComposition.jsl
@@ -44,7 +44,10 @@ entity EntityA {
     field String name;
     field EntityA a;
     field EntityA[] as;
+
     field String childName <= self.a!isDefined() ? self.a.name : "";
+    field String childNameThirdLevel <= self.a.a.name;
+    field String childNameFourthLevel <= self.a.a.a.name;
 }
 
 entity EntityB extends EntityA {
@@ -60,7 +63,8 @@ transfer TransferATO (EntityA entityA) {
     relation TransferATO[] as <=> entityA.as;
 
     field String childName <= entityA.a!isDefined() ? entityA.a.name : "";
-
+    field String childNameThirdLevel <= entityA.a.a.name;
+    field String childNameFourthLevel <= entityA.a.a.a.name;
 }
 
 transfer TransferBTO (EntityB entityB) {
@@ -75,6 +79,8 @@ transfer TransferBTO (EntityB entityB) {
     relation TransferATO[] bas <=> entityB.bas;
 
     field String childName <= entityB.a!isDefined() ? entityB.a.name : "";
+    field String childNameThirdLevel <= entityB.a.a.name;
+    field String childNameFourthLevel <= entityB.a.a.a.name;
 }
 
 transfer TransferAAutoMappedTO (EntityA entityA);

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
         <judo-tatami-jsl-version>1.1.4.20230922_134603_e675cf71_feature_JNG_5089_The_payload_not_contains_the_recursive_single_relation_on_the_sublevels</judo-tatami-jsl-version>
         <judo-runtime-core-version>1.0.6.20230922_132937_59d2c09b_feature_JNG_5089_The_payload_not_contains_the_recursive_single_relation_on_the_sublevels</judo-runtime-core-version>
-        <judo-psm-generator-sdk-core-version>1.0.0.20230921_085028_48c23a0e_develop</judo-psm-generator-sdk-core-version>
+        <judo-psm-generator-sdk-core-version>1.0.0.20230914_120625_a6090a2b_develop</judo-psm-generator-sdk-core-version>
 
 
         <judo-meta-psm-version>1.3.0.20230914_115819_192570cb_develop</judo-meta-psm-version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
 
-        <judo-tatami-jsl-version>1.1.4.20230922_134603_e675cf71_feature_JNG_5089_The_payload_not_contains_the_recursive_single_relation_on_the_sublevels</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230922_132937_59d2c09b_feature_JNG_5089_The_payload_not_contains_the_recursive_single_relation_on_the_sublevels</judo-runtime-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230925_082218_11fad334_feature_JNG_5089_The_payload_not_contains_the_recursive_single_relation_on_the_sublevels</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230925_081834_9c618125_feature_JNG_5089_The_payload_not_contains_the_recursive_single_relation_on_the_sublevels</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230923_041745_dfc4ca09_develop</judo-psm-generator-sdk-core-version>
 
         <judo-meta-psm-version>1.3.0.20230923_041353_5087a8b0_develop</judo-meta-psm-version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,10 @@
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
 
-
         <judo-tatami-jsl-version>1.1.4.20230922_134603_e675cf71_feature_JNG_5089_The_payload_not_contains_the_recursive_single_relation_on_the_sublevels</judo-tatami-jsl-version>
         <judo-runtime-core-version>1.0.6.20230922_132937_59d2c09b_feature_JNG_5089_The_payload_not_contains_the_recursive_single_relation_on_the_sublevels</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230923_041745_dfc4ca09_develop</judo-psm-generator-sdk-core-version>
 
-        
         <judo-meta-psm-version>1.3.0.20230923_041353_5087a8b0_develop</judo-meta-psm-version>
 
         <!-- Code Quality-->

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
 
-        <judo-tatami-jsl-version>1.1.4.20230922_040551_96b4f9a9_develop</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20230921_132957_6a56e8b6_develop</judo-runtime-core-version>
+        <judo-tatami-jsl-version>1.1.4.20230922_134603_e675cf71_feature_JNG_5089_The_payload_not_contains_the_recursive_single_relation_on_the_sublevels</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20230922_132937_59d2c09b_feature_JNG_5089_The_payload_not_contains_the_recursive_single_relation_on_the_sublevels</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230921_085028_48c23a0e_develop</judo-psm-generator-sdk-core-version>
 
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5089" title="JNG-5089" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5089</a>  In the case of recursive composition, if an entity or a TO has both single and collection composite fields, the value of the single field will be null but should be Optional.empty()
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

