### PR TITLE
JNG-5611 add test for single query relation mask

### DIFF
--- a/judo-runtime-core-jsl-itest/models/EntityRelationshipsModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/entity/AssociationRelationshipsTest.java
+++ b/judo-runtime-core-jsl-itest/models/EntityRelationshipsModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/entity/AssociationRelationshipsTest.java
@@ -445,6 +445,20 @@ public class AssociationRelationshipsTest {
         assertNotNull(maskedB.getC().orElseThrow().getName());
         assertNull(maskedB.getC().orElseThrow().getCs());
 
+        maskedB = aDao.queryB(a, BMask.bMask().addByName("c", CMask.cMask().addByName("name"))).orElseThrow();
+
+        assertNull(maskedB.getName());
+        assertNotNull(maskedB.getC());
+        assertNotNull(maskedB.getC().orElseThrow().getName());
+        assertNull(maskedB.getC().orElseThrow().getCs());
+
+        maskedB = aDao.queryB(a.identifier(), BMask.bMask().addByName("c", CMask.cMask().addByName("name"))).orElseThrow();
+
+        assertNull(maskedB.getName());
+        assertNotNull(maskedB.getC());
+        assertNotNull(maskedB.getC().orElseThrow().getName());
+        assertNull(maskedB.getC().orElseThrow().getCs());
+
     }
 
     void checkAMask(A a) {

--- a/judo-runtime-core-jsl-itest/models/EntityRelationshipsModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/entity/CompositionRelationshipsTest.java
+++ b/judo-runtime-core-jsl-itest/models/EntityRelationshipsModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/entity/CompositionRelationshipsTest.java
@@ -207,9 +207,27 @@ public class CompositionRelationshipsTest {
         assertEquals("TEST-C", c.getStringC().orElseThrow());
         assertNotNull(c);
         assertNotNull(c.identifier());
+
+        c = entityADao.querySingleRequiredConA(entityA, EntityCMask.entityCMask().withStringC());
+        assertNull(c.getStringB());
+        assertNull(c.getMultipleDonB());
+        assertNotNull(c.getStringC());
+        assertEquals("TEST-C", c.getStringC().orElseThrow());
+        assertNotNull(c);
+        assertNotNull(c.identifier());
+
+        c = entityADao.querySingleRequiredConA(entityA.identifier(), EntityCMask.entityCMask().withStringC());
+        assertNull(c.getStringB());
+        assertNull(c.getMultipleDonB());
+        assertNotNull(c.getStringC());
+        assertEquals("TEST-C", c.getStringC().orElseThrow());
+        assertNotNull(c);
+        assertNotNull(c.identifier());
+
+        EntityC finalC = c;
         IllegalStateException exception = assertThrows(
                 IllegalStateException.class,
-                () -> entityCDao.delete(c.identifier())
+                () -> entityCDao.delete(finalC.identifier())
         );
 
         assertThat(exception.getMessage(), CoreMatchers.startsWith("There are mandatory references that cannot be removed"));

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
             javax.resource;version="[1.6,2)"
         </osgi-transaction-import>
 
-        <judo-tatami-jsl-version>1.1.4.20240313_041925_d4db8010_develop</judo-tatami-jsl-version>
-        <judo-runtime-core-version>1.0.6.20240313_041545_ea0f269e_develop</judo-runtime-core-version>
-        <judo-psm-generator-sdk-core-version>1.0.0.20240313_041300_d16cc314_develop</judo-psm-generator-sdk-core-version>
+        <judo-tatami-jsl-version>1.1.4.20240313_122101_24a96f23_feature_JNG_5266_Test_the_eager_modifier_SDK_functionality</judo-tatami-jsl-version>
+        <judo-runtime-core-version>1.0.6.20240313_121638_1ccd703e_feature_JNG_5266_Test_the_eager_modifier_SDK_functionality</judo-runtime-core-version>
+        <judo-psm-generator-sdk-core-version>1.0.0.20240313_133252_d25fb564_feature_JNG_5611_Mask_parameter_is_missing_from_single_relation_query_functions_on_dao_interfaces</judo-psm-generator-sdk-core-version>
 
         <judo-meta-psm-version>1.3.0.20240127_122224_4f1de775_develop</judo-meta-psm-version>
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5611" title="JNG-5611" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5611</a>  Mask parameter is missing from single relation query functions on dao interfaces
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

