### PR TITLE
JNG-4986 Bad sql grammar exception inherited navigation after any

### DIFF
--- a/judo-runtime-core-jsl-itest/models/NavigationTestModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/entity/NavigationTest.java
+++ b/judo-runtime-core-jsl-itest/models/NavigationTestModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/entity/NavigationTest.java
@@ -33,6 +33,9 @@ import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigati
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.a3.A3;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.a3.A3Dao;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.a3.A3ForCreate;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.ac.AC;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.ac.ACDao;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.ac.ACForCreate;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.ap.AP;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.ap.APDao;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.ap.APForCreate;
@@ -105,7 +108,8 @@ import static com.google.common.collect.ImmutableSet.of;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -209,8 +213,6 @@ class NavigationTest {
         assertThat(aDao.queryClistTroughDerivedSelf(a).selectList().stream().map(e -> e.identifier().getIdentifier()).toList(),
                 containsInAnyOrder(c1.identifier().getIdentifier(), c2.identifier().getIdentifier()));
 
-        Optional<B> b = aDao.queryOneBOnFilteredA(a);
-
     }
 
     private void assertEmptyBAndC(A a) {
@@ -237,8 +239,12 @@ class NavigationTest {
         assertEmpty(a.getBbAllCAnyName());
     }
 
+    @Inject
+    ACDao acDao;
+
     @Test
-    @TestCase("DoubleAnyInNavigation")
+    @Disabled("https://blackbelt.atlassian.net/browse/JNG-4986")
+    @TestCase("InheritedRelationNavigationAfterAny")
     @Requirement(reqs = {
             "REQ-TYPE-001",
             "REQ-ENT-001",
@@ -246,6 +252,7 @@ class NavigationTest {
             "REQ-ENT-004",
             "REQ-ENT-005",
             "REQ-ENT-008",
+            "REQ-ENT-012",
             "REQ-EXPR-001",
             "REQ-EXPR-002",
             "REQ-EXPR-003",
@@ -254,19 +261,19 @@ class NavigationTest {
             "REQ-EXPR-008",
             "REQ-EXPR-022"
     })
-    public void testDoubleAnyInNavigation() {
+    public void testInheritedRelationNavigationAfterAny() {
         B b1 = bDao.create(BForCreate.builder().withName("sameName").build());
         B b2 = bDao.create(BForCreate.builder().withName("sameName").build());
-        A a = aDao.create(AForCreate.builder().withBlist(List.of(b1, b2)).build());
+        AC ac = acDao.create(ACForCreate.builder().withBlist(List.of(b1, b2)).build());
 
-        Optional<B> oneBOnFilteredA = aDao.queryOneBOnFilteredA(a);
+        Optional<B> oneBOnFilteredA = acDao.queryOneBOnFilteredA(ac);
         assertTrue(oneBOnFilteredA.isPresent());
         assertThat(List.of(b1.identifier(), b2.identifier()), hasItem(oneBOnFilteredA.get().identifier()));
 
-        aDao.delete(a);
+        acDao.delete(ac);
 
-        A a1 = aDao.create(AForCreate.builder().build());
-        assertTrue( aDao.queryOneBOnFilteredA(a1).isEmpty());
+        AC ac1 = acDao.create(ACForCreate.builder().build());
+        assertTrue( acDao.queryOneBOnFilteredA(ac1).isEmpty());
     }
 
         @SuppressWarnings("unchecked")

--- a/judo-runtime-core-jsl-itest/models/NavigationTestModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/MappedTransferNavigationTest.java
+++ b/judo-runtime-core-jsl-itest/models/NavigationTestModel/src/test/java/hu/blackbelt/judo/runtime/core/jsl/transfer/MappedTransferNavigationTest.java
@@ -23,7 +23,6 @@ package hu.blackbelt.judo.runtime.core.jsl.transfer;
 import com.google.inject.Inject;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.a.A;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.a.ADao;
-import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.a.AForCreate;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.a.AIdentifier;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.b.BDao;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.c.CDao;
@@ -31,6 +30,9 @@ import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigati
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.ta.TA;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.ta.TADao;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.ta.TAForCreate;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.tac.TAC;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.tac.TACDao;
+import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.tac.TACForCreate;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.tb.TB;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.tb.TBDao;
 import hu.blackbelt.judo.psm.generator.sdk.core.test.api.navigationtest.navigationtest.tb.TBForCreate;
@@ -52,6 +54,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -62,11 +65,9 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -191,8 +192,12 @@ class MappedTransferNavigationTest {
 
     }
 
+    @Inject
+    TACDao tacDao;
+
     @Test
-    @TestCase("DoubleAnyInNavigationOnTransfer")
+    @Disabled("https://blackbelt.atlassian.net/browse/JNG-4986")
+    @TestCase("InheritedRelationNavigationAfterAny")
     @Requirement(reqs = {
             "REQ-TYPE-001",
             "REQ-ENT-001",
@@ -200,6 +205,7 @@ class MappedTransferNavigationTest {
             "REQ-ENT-004",
             "REQ-ENT-005",
             "REQ-ENT-008",
+            "REQ-ENT-012",
             "REQ-EXPR-001",
             "REQ-EXPR-002",
             "REQ-EXPR-003",
@@ -209,19 +215,19 @@ class MappedTransferNavigationTest {
             "REQ-EXPR-022",
             "REQ-SRV-003"
     })
-    public void testDoubleAnyInNavigationOnTransfer() {
+    public void testInheritedRelationNavigationAfterAnyOnTransfer() {
         TB b1 = tbDao.create(TBForCreate.builder().withName("sameName").build());
         TB b2 = tbDao.create(TBForCreate.builder().withName("sameName").build());
-        TA a = taDao.create(TAForCreate.builder().withBlist(List.of(b1, b2)).build());
+        TAC ac = tacDao.create(TACForCreate.builder().withBlist(List.of(b1, b2)).build());
 
-        Optional<TB> oneBOnFilteredA = taDao.queryOneBOnFilteredA(a);
+        Optional<TB> oneBOnFilteredA = tacDao.queryOneBOnFilteredA(ac);
         assertTrue(oneBOnFilteredA.isPresent());
         assertThat(List.of(b1.identifier(), b2.identifier()), hasItem(oneBOnFilteredA.get().identifier()));
 
-        taDao.delete(a);
+        tacDao.delete(ac);
 
-        A a1 = aDao.create(AForCreate.builder().build());
-        assertTrue( aDao.queryOneBOnFilteredA(a1).isEmpty());
+        TAC ac1 = tacDao.create(TACForCreate.builder().build());
+        assertTrue( tacDao.queryOneBOnFilteredA(ac1).isEmpty());
     }
 
     private void assertEmptyBAndC(TA ta) {

--- a/judo-runtime-core-jsl-itest/models/NavigationTestModel/src/test/resources/NavigationTest.jsl
+++ b/judo-runtime-core-jsl-itest/models/NavigationTestModel/src/test/resources/NavigationTest.jsl
@@ -33,7 +33,11 @@ entity A {
     relation B[] blistTroughDerivedSelf <= self.`self`.blist;
     relation C[] clistTroughDerivedSelf <= self.`self`.blist.c;
 
-    relation B oneBOnFilteredA <= A.all().filter( a | a.blist.size() > 0).any().blist.filter( b | b.name == "sameName").any();
+}
+
+entity AC extends A {
+    // error after the first any navigation
+    relation B oneBOnFilteredA <= AC.all().filter( a | a.blist.size() > 0).any().blist.filter( b | b.name == "sameName").any();
 }
 
 transfer TA (A mapped) {
@@ -66,8 +70,13 @@ transfer TA (A mapped) {
     relation TB[] blistTroughDerivedSelf <= mapped.blistTroughDerivedSelf;
     relation TC[] clistTroughDerivedSelf <= mapped.clistTroughDerivedSelf;
 
-     relation TB oneBOnFilteredA <= mapped.oneBOnFilteredA;
 }
+
+transfer TAC (AC mapped) {
+    relation TB[] blist <= mapped.blist choices:B.all();
+    relation TB oneBOnFilteredA <= mapped.oneBOnFilteredA;
+}
+
 
 entity B {
     field String name;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4986" title="JNG-4986" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4986</a>  Navigation in inherited relations after !any() results bad sql grammar exception at runtime
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
JNG-4986 Bad sql grammar exception inherited navigation after any